### PR TITLE
make libtorch build on darwin

### DIFF
--- a/libtorch/generic.nix
+++ b/libtorch/generic.nix
@@ -53,6 +53,6 @@ stdenv.mkDerivation rec {
     description = "libtorch";
     homepage = https://pytorch.org/;
     license = licenses.bsd3;
-    platforms = with platforms; [ linux ] ++ stdenv.lib.optionals (!cudaSupport) [ darwin ];
+    platforms = with platforms; platforms.all; #[ linux ] ++ stdenv.lib.optionals (!cudaSupport) [ darwin ];
   };
 }

--- a/libtorch/generic.nix
+++ b/libtorch/generic.nix
@@ -25,7 +25,8 @@ stdenv.mkDerivation rec {
   inherit version;
 
   src = fetchzip {
-    url = "https://download.pytorch.org/libtorch/${buildtype}/libtorch-shared-with-deps-latest.zip";
+    # url = "https://download.pytorch.org/libtorch/${buildtype}/libtorch-shared-with-deps-latest.zip";
+    url = "https://download.pytorch.org/libtorch/${buildtype}/libtorch-macos-1.1.0.zip";
     inherit sha256;
   };
 
@@ -52,6 +53,6 @@ stdenv.mkDerivation rec {
     description = "libtorch";
     homepage = https://pytorch.org/;
     license = licenses.bsd3;
-    platforms = with platforms; [ darwin linux ];
+    platforms = with platforms; [ linux ] ++ stdenv.lib.optionals (!cudaSupport) [ darwin ];
   };
 }

--- a/libtorch/generic.nix
+++ b/libtorch/generic.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchzip, autoreconfHook, gettext
-, version, sha256
+, version, mkSrc
 , cudaSupport ? false, cudatoolkit ? null, cudnn ? null
 , mklSupport ? false , mkl ? null}:
 
@@ -15,8 +15,7 @@ let
       nightly + arch;
 in
 
-# stable cuda 10 doesn't exist yet
-assert cudaSupport == false || (cudatoolkit != null && cudnn != null && cudaMajor == "9" && cudaMinor == "0");
+assert cudaSupport == false || (cudatoolkit != null && cudnn != null);
 assert mklSupport == false || mkl != null;
 assert version == "1.1" || version == "nightly";
 
@@ -24,11 +23,7 @@ stdenv.mkDerivation rec {
   name = "libtorch-${version}";
   inherit version;
 
-  src = fetchzip {
-    # url = "https://download.pytorch.org/libtorch/${buildtype}/libtorch-shared-with-deps-latest.zip";
-    url = "https://download.pytorch.org/libtorch/${buildtype}/libtorch-macos-1.1.0.zip";
-    inherit sha256;
-  };
+  src = mkSrc buildtype;
 
   propagatedBuildInputs = []
     ++ stdenv.lib.optionals cudaSupport [ cudatoolkit cudnn ]
@@ -53,6 +48,6 @@ stdenv.mkDerivation rec {
     description = "libtorch";
     homepage = https://pytorch.org/;
     license = licenses.bsd3;
-    platforms = with platforms; platforms.all; #[ linux ] ++ stdenv.lib.optionals (!cudaSupport) [ darwin ];
+    platforms = with platforms; linux ++ stdenv.lib.optionals (!cudaSupport) darwin;
   };
 }

--- a/libtorch/release.nix
+++ b/libtorch/release.nix
@@ -13,7 +13,8 @@ in
 {
   libtorch_cpu = callCpu {
     version = "1.1";
-    sha256 = "09iwdy31zg9dzkrjx8mwpds9mxrv775msn01v1njkpjymvi7llz6";
+    # sha256 = "09iwdy31zg9dzkrjx8mwpds9mxrv775msn01v1njkpjymvi7llz6";
+    sha256 = "03wqgvmyz2dv5iin27rnhxy6blk7gf0h49vgwmnab9c5j43y2y3d";
   };
   libtorch_cudatoolkit_9_0 = callGpu {
     version = "1.1";

--- a/libtorch/release.nix
+++ b/libtorch/release.nix
@@ -13,13 +13,40 @@ in
 {
   libtorch_cpu = callCpu {
     version = "1.1";
-    # sha256 = "09iwdy31zg9dzkrjx8mwpds9mxrv775msn01v1njkpjymvi7llz6";
-    sha256 = "03wqgvmyz2dv5iin27rnhxy6blk7gf0h49vgwmnab9c5j43y2y3d";
+    mkSrc = buildtype:
+      if stdenv.hostPlatform.system == "x86_64-linux" then
+        fetchzip {
+          url = "https://download.pytorch.org/libtorch/${buildtype}/libtorch-shared-with-deps-latest.zip";
+          sha256 = "09iwdy31zg9dzkrjx8mwpds9mxrv775msn01v1njkpjymvi7llz6";
+        }
+      else if stdenv.hostPlatform.system == "x86_64-darwin" then
+        fetchzip {
+          url = "https://download.pytorch.org/libtorch/${buildtype}/libtorch-macos-1.1.0.zip";
+          sha256 = "03wqgvmyz2dv5iin27rnhxy6blk7gf0h49vgwmnab9c5j43y2y3d";
+        }
+      else throw "missing url for platform ${stdenv.hostPlatform.system}";
+  };
+  libtorch_cudatoolkit_10_0 = callGpu {
+    version = "1.1";
+    mkSrc = buildtype:
+      if stdenv.hostPlatform.system == "x86_64-linux" then
+        fetchzip {
+          url = "https://download.pytorch.org/libtorch/${buildtype}/libtorch-shared-with-deps-latest.zip";
+          sha256 = "0wl9xnv6bbpp0f93iwidvf7n1ns2nbd8ykyc9r163s3f04l295k3";
+        }
+      else throw "missing url for platform ${stdenv.hostPlatform.system}";
+    cudatoolkit = cudatoolkit_10_0;
+    cudnn = cudnn_cudatoolkit_10_0;
   };
   libtorch_cudatoolkit_9_0 = callGpu {
     version = "1.1";
-    # sha256 = "1y1kjqnqmac5cfl2cgdk2py5pwcxsyr6g2bk09spjs2d6g9cszld";
-    sha256 = "0wl9xnv6bbpp0f93iwidvf7n1ns2nbd8ykyc9r163s3f04l295k3";
+    mkSrc = buildtype:
+      if stdenv.hostPlatform.system == "x86_64-linux" then
+        fetchzip {
+          url = "https://download.pytorch.org/libtorch/${buildtype}/libtorch-shared-with-deps-latest.zip";
+          sha256 = "0wl9xnv6bbpp0f93iwidvf7n1ns2nbd8ykyc9r163s3f04l295k3";
+        }
+      else throw "missing url for platform ${stdenv.hostPlatform.system}";
     cudatoolkit = cudatoolkit_9_0;
     cudnn = cudnn_cudatoolkit_9_0;
   };
@@ -27,17 +54,40 @@ in
   nightly = {
     libtorch_cpu = callCpu {
       version = "nightly";
-      sha256 = "1dy85vqf13zk911y84aml0niz79p8v7x2lwy7jsbk1ixj36p2zsy";
+      mkSrc = buildtype:
+        if stdenv.hostPlatform.system == "x86_64-linux" then
+          fetchzip {
+            url = "https://download.pytorch.org/libtorch/${buildtype}/libtorch-shared-with-deps-latest.zip";
+            sha256 = "1dy85vqf13zk911y84aml0niz79p8v7x2lwy7jsbk1ixj36p2zsy";
+          }
+        else if stdenv.hostPlatform.system == "x86_64-darwin" then
+          fetchzip {
+            url = "https://download.pytorch.org/libtorch/${buildtype}/libtorch-macos-latest.zip";
+            sha256 = "03wqgvmyz2dv5iin27rnhxy6blk7gf0h49vgwmnab9c5j43y2y3d";
+          }
+        else throw "missing url for platform ${stdenv.hostPlatform.system}";
     };
     libtorch_cudatoolkit_10_0 = callGpu {
       version = "nightly";
-      sha256 = "1cvdrglgjn32dk904wz1l9lys06r8nn1xdhcx9rmyylpav89inic";
+      mkSrc = buildtype:
+        if stdenv.hostPlatform.system == "x86_64-linux" then
+          fetchzip {
+            url = "https://download.pytorch.org/libtorch/${buildtype}/libtorch-shared-with-deps-latest.zip";
+            sha256 = "1cvdrglgjn32dk904wz1l9lys06r8nn1xdhcx9rmyylpav89inic";
+          }
+        else throw "missing url for platform ${stdenv.hostPlatform.system}";
       cudatoolkit = cudatoolkit_10_0;
       cudnn = cudnn_cudatoolkit_10_0;
     };
     libtorch_cudatoolkit_9_0 = callGpu {
       version = "nightly";
-      sha256 = "123r3xi2n6dbscvlcd6b2x7mglidkc3zybxg1lxwm5kk5n27r93p";
+      mkSrc = buildtype:
+        if stdenv.hostPlatform.system == "x86_64-linux" then
+          fetchzip {
+            url = "https://download.pytorch.org/libtorch/${buildtype}/libtorch-shared-with-deps-latest.zip";
+            sha256 = "123r3xi2n6dbscvlcd6b2x7mglidkc3zybxg1lxwm5kk5n27r93p";
+          }
+        else throw "missing url for platform ${stdenv.hostPlatform.system}";
       cudatoolkit = cudatoolkit_9_0;
       cudnn = cudnn_cudatoolkit_9_0;
     };

--- a/libtorch/release.nix
+++ b/libtorch/release.nix
@@ -63,7 +63,7 @@ in
         else if stdenv.hostPlatform.system == "x86_64-darwin" then
           fetchzip {
             url = "https://download.pytorch.org/libtorch/${buildtype}/libtorch-macos-latest.zip";
-            sha256 = "03wqgvmyz2dv5iin27rnhxy6blk7gf0h49vgwmnab9c5j43y2y3d";
+            sha256 = "15bb1dbjj4hl60sh7x45wz5nfvik7cw9fa3iqw2qav0bn6l1f1kf";
           }
         else throw "missing url for platform ${stdenv.hostPlatform.system}";
     };

--- a/release.nix
+++ b/release.nix
@@ -6,7 +6,7 @@ let
   libtorch-releases = pkgs.callPackage ./libtorch/release.nix { };
 in
 {
-  inherit (libtorch-releases) libtorch_cpu libtorch_cudatoolkit_9_0;
+  inherit (libtorch-releases) libtorch_cpu libtorch_cudatoolkit_10_0 libtorch_cudatoolkit_9_0;
 
   inherit (pytorch-releases) magma_240 pytorch36-vanilla pytorch36-mkl pytorch36-cu;
 


### PR DESCRIPTION
I've tried:
* `NIXPKGS_ALLOW_UNFREE=1 nix-build --attr libtorch_cpu release.nix` on a mac
* `NIXPKGS_ALLOW_UNFREE=1 nix-build --attr libtorch_cpu release.nix` on linux
* `NIXPKGS_ALLOW_UNFREE=1 nix-build --attr libtorch_cudatoolkit_10_0 release.nix` on linux
* `NIXPKGS_ALLOW_UNFREE=1 nix-build --attr libtorch_cudatoolkit_9_0 release.nix` on linux
* `NIXPKGS_ALLOW_UNFREE=1 nix-build --attr nightly.libtorch_cpu libtorch/release.nix` on a mac

and they all build successfully.
~I've also added a `darwin` version of `nightly.libtorch_cpu`, but the hash should be incorrect. However, when I tried to build it with `NIXPKGS_ALLOW_UNFREE=1 nix-build --attr nightly.libtorch_cpu libtorch/release.nix`, it worked for some reason. I'm a bit puzzled since I was expecting a hash mismatch. There could be a bug in resolving the `nightly` build type...~
I think it was a caching issue, I fixed it now.