### PR TITLE
Feature/libtorch 1.2 with mklml

### DIFF
--- a/.github/workflows/nix-macos.yml
+++ b/.github/workflows/nix-macos.yml
@@ -1,0 +1,19 @@
+name: Haskell CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: macOS-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Setup nix
+      run: |
+        git submodule init && git submodule update
+        curl https://nixos.org/nix/install | sh
+    - name: Build
+      run: |
+        . /Users/runner/.nix-profile/etc/profile.d/nix.sh
+        mkdir -p ~/.config/nixpkgs
+        echo  '{ allowUnfree = true; }' >  ~/.config/nixpkgs/config.nix
+        cd libtorch;nix-build -E '((import <nixpkgs>) {}).callPackages ./release.nix {}'

--- a/libtorch/mklml.nix
+++ b/libtorch/mklml.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchzip
+}:
+
+stdenv.mkDerivation rec {
+  name = "libmklml";
+  version = "0.17.2";
+  src =
+    if stdenv.hostPlatform.system == "x86_64-linux" then
+      fetchzip {
+        url = "https://github.com/intel/mkl-dnn/releases/download/v0.17.2/mklml_lnx_2019.0.1.20181227.tgz";
+        sha256 = "0g9fd97pcbzsfslj8j517jwl2rflqqsph3dny553pw62gqiy92gr";
+      }
+    else if stdenv.hostPlatform.system == "x86_64-darwin" then
+      fetchzip {
+        url = "https://github.com/intel/mkl-dnn/releases/download/v0.17.2/mklml_mac_2019.0.1.20181227.tgz";
+        sha256 = "01vbvp1khd118rskcaszwl0vw7z30bnwqcs88ah4fj1i9q5k7z7k";
+      }
+    else throw "missing url for platform ${stdenv.hostPlatform.system}";
+
+  preFixup = stdenv.lib.optionalString stdenv.isDarwin ''
+    echo "-- before fixup --"
+    for f in $(ls $out/lib/*.dylib); do
+        otool -L $f
+    done
+    for f in $(ls $out/lib/*.dylib); do
+        install_name_tool -id @rpath/$(basename $f) $f || true
+    done
+    install_name_tool -change @rpath/libiomp5.dylib $out/lib/libiomp5.dylib $out/lib/libmklml.dylib
+    echo "-- after fixup --"
+    for f in $(ls $out/lib/*.dylib); do
+        otool -L $f
+    done
+  '';
+
+  installPhase = ''
+    ls $src
+    mkdir $out
+    cp -r {$src,$out}/include/
+    cp -r {$src,$out}/lib/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "libmklml";
+    homepage = https://software.intel.com/en-us/mkl;
+    license = { free = false; fullName = "Intel Simplified Software License"; shortName = "issl"; url = "https://software.intel.com/en-us/license/intel-simplified-software-license"; };
+    platforms = with platforms; linux ++ darwin;
+  };
+}

--- a/libtorch/release.nix
+++ b/libtorch/release.nix
@@ -26,7 +26,7 @@ in
           sha256 = "0vh5fw9h1rydp2bbrlkq54z29p1v0lpfmllddk82sgz7sr3jld66";
         }
       else if stdenv.hostPlatform.system == "x86_64-darwin" then
-        fetchzip {
+        (import <nixpkgs> {}).fetchzip {
           url = "https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.2.0.zip";
           sha256 = "0qglhy7dpjxcn24q41wp0n8dflypbmfk6mqzafavi2jfhl33wac2";
         }

--- a/libtorch/release.nix
+++ b/libtorch/release.nix
@@ -3,93 +3,55 @@
 with pkgs;
 
 let
-  callCpu = opts: callPackage ./generic.nix ({ mklSupport = true; } // opts);
+  libmklml = opts: callPackage ./mklml.nix ({
+  } // opts);
+  callCpu = opts: callPackage ./generic.nix ({
+    mklml = libmklml {};
+    libcxx = libcxx;
+  } // opts);
   callGpu = opts: callPackage ./generic.nix ({
-    mklSupport = true;
-    cudaSupport = true;
+    mklml = libmklml {};
+    libcxx = libcxx;
   } // opts);
 in
-
 {
+  libmklml = libmklml {};
   libtorch_cpu = callCpu {
-    version = "1.1";
+    version = "1.2";
+    buildtype = "cpu";
     mkSrc = buildtype:
       if stdenv.hostPlatform.system == "x86_64-linux" then
         fetchzip {
-          url = "https://download.pytorch.org/libtorch/${buildtype}/libtorch-shared-with-deps-latest.zip";
-          sha256 = "09iwdy31zg9dzkrjx8mwpds9mxrv775msn01v1njkpjymvi7llz6";
+          url = "https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.2.0.zip";
+          sha256 = "0vh5fw9h1rydp2bbrlkq54z29p1v0lpfmllddk82sgz7sr3jld66";
         }
       else if stdenv.hostPlatform.system == "x86_64-darwin" then
         fetchzip {
-          url = "https://download.pytorch.org/libtorch/${buildtype}/libtorch-macos-1.1.0.zip";
-          sha256 = "03wqgvmyz2dv5iin27rnhxy6blk7gf0h49vgwmnab9c5j43y2y3d";
+          url = "https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.2.0.zip";
+          sha256 = "0qglhy7dpjxcn24q41wp0n8dflypbmfk6mqzafavi2jfhl33wac2";
         }
       else throw "missing url for platform ${stdenv.hostPlatform.system}";
   };
-  libtorch_cudatoolkit_10_0 = callGpu {
-    version = "1.1";
+  ${if stdenv.hostPlatform.system == "x86_64-darwin" then null else "libtorch_cudatoolkit_10_0"} = callGpu {
+    version = "cu100-1.2";
+    buildtype = "cu100";
     mkSrc = buildtype:
       if stdenv.hostPlatform.system == "x86_64-linux" then
         fetchzip {
-          url = "https://download.pytorch.org/libtorch/${buildtype}/libtorch-shared-with-deps-latest.zip";
-          sha256 = "0wl9xnv6bbpp0f93iwidvf7n1ns2nbd8ykyc9r163s3f04l295k3";
+          url = "https://download.pytorch.org/libtorch/cu100/libtorch-cxx11-abi-shared-with-deps-1.2.0.zip";
+          sha256 = "1xr91pm5w6w62277lkcz5wnnqm28a62xydx9ak4c1p3jrp0g39gk";
         }
       else throw "missing url for platform ${stdenv.hostPlatform.system}";
-    cudatoolkit = cudatoolkit_10_0;
-    cudnn = cudnn_cudatoolkit_10_0;
   };
-  libtorch_cudatoolkit_9_0 = callGpu {
-    version = "1.1";
+  ${if stdenv.hostPlatform.system == "x86_64-darwin" then null else "libtorch_cudatoolkit_9_2"} = callGpu {
+    version = "cu92-1.2";
+    buildtype = "cu92";
     mkSrc = buildtype:
       if stdenv.hostPlatform.system == "x86_64-linux" then
         fetchzip {
-          url = "https://download.pytorch.org/libtorch/${buildtype}/libtorch-shared-with-deps-latest.zip";
-          sha256 = "0wl9xnv6bbpp0f93iwidvf7n1ns2nbd8ykyc9r163s3f04l295k3";
+          url = "https://download.pytorch.org/libtorch/cu92/libtorch-cxx11-abi-shared-with-deps-1.2.0.zip";
+          sha256 = "0xsq7fw2d36wsfha04dcdd5fwi24h8hg7hqkd7l29g1cpfcvr4na";
         }
       else throw "missing url for platform ${stdenv.hostPlatform.system}";
-    cudatoolkit = cudatoolkit_9_0;
-    cudnn = cudnn_cudatoolkit_9_0;
-  };
-
-  nightly = {
-    libtorch_cpu = callCpu {
-      version = "nightly";
-      mkSrc = buildtype:
-        if stdenv.hostPlatform.system == "x86_64-linux" then
-          fetchzip {
-            url = "https://download.pytorch.org/libtorch/${buildtype}/libtorch-shared-with-deps-latest.zip";
-            sha256 = "1dy85vqf13zk911y84aml0niz79p8v7x2lwy7jsbk1ixj36p2zsy";
-          }
-        else if stdenv.hostPlatform.system == "x86_64-darwin" then
-          fetchzip {
-            url = "https://download.pytorch.org/libtorch/${buildtype}/libtorch-macos-latest.zip";
-            sha256 = "15bb1dbjj4hl60sh7x45wz5nfvik7cw9fa3iqw2qav0bn6l1f1kf";
-          }
-        else throw "missing url for platform ${stdenv.hostPlatform.system}";
-    };
-    libtorch_cudatoolkit_10_0 = callGpu {
-      version = "nightly";
-      mkSrc = buildtype:
-        if stdenv.hostPlatform.system == "x86_64-linux" then
-          fetchzip {
-            url = "https://download.pytorch.org/libtorch/${buildtype}/libtorch-shared-with-deps-latest.zip";
-            sha256 = "1cvdrglgjn32dk904wz1l9lys06r8nn1xdhcx9rmyylpav89inic";
-          }
-        else throw "missing url for platform ${stdenv.hostPlatform.system}";
-      cudatoolkit = cudatoolkit_10_0;
-      cudnn = cudnn_cudatoolkit_10_0;
-    };
-    libtorch_cudatoolkit_9_0 = callGpu {
-      version = "nightly";
-      mkSrc = buildtype:
-        if stdenv.hostPlatform.system == "x86_64-linux" then
-          fetchzip {
-            url = "https://download.pytorch.org/libtorch/${buildtype}/libtorch-shared-with-deps-latest.zip";
-            sha256 = "123r3xi2n6dbscvlcd6b2x7mglidkc3zybxg1lxwm5kk5n27r93p";
-          }
-        else throw "missing url for platform ${stdenv.hostPlatform.system}";
-      cudatoolkit = cudatoolkit_9_0;
-      cudnn = cudnn_cudatoolkit_9_0;
-    };
   };
 }

--- a/libtorch/release.nix
+++ b/libtorch/release.nix
@@ -26,7 +26,7 @@ in
           sha256 = "0vh5fw9h1rydp2bbrlkq54z29p1v0lpfmllddk82sgz7sr3jld66";
         }
       else if stdenv.hostPlatform.system == "x86_64-darwin" then
-        (import <nixpkgs> {}).fetchzip {
+        fetchzip {
           url = "https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.2.0.zip";
           sha256 = "0qglhy7dpjxcn24q41wp0n8dflypbmfk6mqzafavi2jfhl33wac2";
         }


### PR DESCRIPTION
* I want to use this package to avoid ghc's panic of https://gitlab.haskell.org/ghc/ghc/issues/16130.
* Update prebuild-libtorch to 1.2
* Include prebuild-mklml which hasktorch's CI uses.
* Drop cudatoolkit. We do not need it to use libtorch necessarily.
* Drop nightly build. It is not stable. So the hash is not stable, too.