### PR TITLE
don't strip libtorch

### DIFF
--- a/libtorch/generic.nix
+++ b/libtorch/generic.nix
@@ -55,6 +55,8 @@ stdenv.mkDerivation rec {
     cp -r {$src,$out}/share/
   '';
 
+  dontStrip = true;
+
   meta = with stdenv.lib; {
     description = "libtorch";
     homepage = https://pytorch.org/;


### PR DESCRIPTION
to resolve `dist/build/spec/spec: error while loading shared libraries: libtorch.so: ELF load command address/offset not properly aligned` downstream in hasktorch, see https://github.com/hasktorch/hasktorch/pull/188