### PR TITLE
Upgrade libtorch to 1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,20 +38,20 @@ Features
 
 The current features are supported:
 
-| **Python-3.6.9 support**            | pytorch-v1.1.0     | pytorch-v1.2.0     |
-| ----------------------------------- | ------------------ | ------------------ |
-| vanilla                             | :heavy_check_mark: | :heavy_check_mark: |
-| mkl+mkldnn                          | :heavy_check_mark: | :heavy_check_mark: |
-| openMPI                             | :heavy_check_mark: | :heavy_check_mark: |
-| FBGEMM                              | :x:                | :heavy_check_mark: |
-| Full CPU (all above)*               | :heavy_check_mark: | :heavy_check_mark: |
-| Full CPU + NamedTensors + Binaries  | :grey_exclamation: | :heavy_check_mark: |
-| CUDA                                | :heavy_check_mark: | :heavy_check_mark: |
-| CUDA+NCCL                           | :heavy_check_mark: | :heavy_check_mark: |
-| CUDA+NCCL+openMPI                   | :heavy_check_mark: | :heavy_check_mark: |
-| CUDA+NCCL+openMPI+mkl               | :heavy_check_mark: | :heavy_check_mark: |
-| Full CUDA (all above)*              | :heavy_check_mark: | :heavy_check_mark: |
-| Full CUDA + NamedTensors + Binaries | :grey_exclamation: | :heavy_check_mark: |
+| **Python-3.6.9 support**            | pytorch-v1.1.0     | pytorch-v1.2.0     | libtorch-v1.3.0    |
+| ----------------------------------- | ------------------ | ------------------ | ------------------ |
+| vanilla                             | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| mkl+mkldnn                          | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| openMPI                             | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| FBGEMM                              | :x:                | :heavy_check_mark: | :heavy_check_mark: |
+| Full CPU (all above)*               | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| Full CPU + NamedTensors + Binaries  | :grey_exclamation: | :heavy_check_mark: | :heavy_check_mark: |
+| CUDA                                | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| CUDA+NCCL                           | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| CUDA+NCCL+openMPI                   | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| CUDA+NCCL+openMPI+mkl               | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| Full CUDA (all above)*              | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| Full CUDA + NamedTensors + Binaries | :grey_exclamation: | :heavy_check_mark: | :heavy_check_mark: |
 
 The ":grey_exclamation:" means that namedtensors and binaries weren't attempted in pytorch-v1.1.0.
 

--- a/libtorch/generic.nix
+++ b/libtorch/generic.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchzip, autoreconfHook, gettext
-, version ? "1.2", mkSrc, buildtype
+, version ? "1.3", mkSrc, buildtype
 , mklml ? null
 , libcxx ? null
 }:

--- a/libtorch/release.nix
+++ b/libtorch/release.nix
@@ -17,7 +17,7 @@ in
 {
   libmklml = libmklml {};
   libtorch_cpu = callCpu {
-    version = "1.2";
+    version = "1.3";
     buildtype = "cpu";
     mkSrc = buildtype:
       if stdenv.hostPlatform.system == "x86_64-linux" then

--- a/libtorch/release.nix
+++ b/libtorch/release.nix
@@ -22,35 +22,39 @@ in
     mkSrc = buildtype:
       if stdenv.hostPlatform.system == "x86_64-linux" then
         fetchzip {
-          url = "https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.2.0.zip";
-          sha256 = "0vh5fw9h1rydp2bbrlkq54z29p1v0lpfmllddk82sgz7sr3jld66";
+          # Source file is  "https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.3.0%2Bcpu.zip".
+          # Nix can not use the url directly, because this link includes '%2B'.
+          url = "https://github.com/hasktorch/libtorch-binary-for-ci/releases/download/1.3.0/cpu-libtorch-cxx11-abi-shared-with-deps-latest.zip";
+          sha256 = "0xkbhrgfl4zfp70zxssvigq9yns7pfczwa09ayxkqjnq8hr1i32n";
         }
       else if stdenv.hostPlatform.system == "x86_64-darwin" then
         fetchzip {
-          url = "https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.2.0.zip";
-          sha256 = "0qglhy7dpjxcn24q41wp0n8dflypbmfk6mqzafavi2jfhl33wac2";
+          url = "https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.3.0.zip";
+          sha256 = "11rwa8hxxs0n48qq91z8hi29l484js7ajxc34i58s7lxspw7hdaf";
         }
       else throw "missing url for platform ${stdenv.hostPlatform.system}";
   };
-  ${if stdenv.hostPlatform.system == "x86_64-darwin" then null else "libtorch_cudatoolkit_10_0"} = callGpu {
-    version = "cu100-1.2";
-    buildtype = "cu100";
+  ${if stdenv.hostPlatform.system == "x86_64-darwin" then null else "libtorch_cudatoolkit_10_1"} = callGpu {
+    version = "cu101-1.3";
+    buildtype = "cu101";
     mkSrc = buildtype:
       if stdenv.hostPlatform.system == "x86_64-linux" then
         fetchzip {
-          url = "https://download.pytorch.org/libtorch/cu100/libtorch-cxx11-abi-shared-with-deps-1.2.0.zip";
-          sha256 = "1xr91pm5w6w62277lkcz5wnnqm28a62xydx9ak4c1p3jrp0g39gk";
+          url = "https://download.pytorch.org/libtorch/cu101/libtorch-cxx11-abi-shared-with-deps-1.3.0.zip";
+          sha256 = "0wbhab2gy3wmsni3nm3z15kw3w579ah68b2ikngxdrgw77z1rqr7";
         }
       else throw "missing url for platform ${stdenv.hostPlatform.system}";
   };
   ${if stdenv.hostPlatform.system == "x86_64-darwin" then null else "libtorch_cudatoolkit_9_2"} = callGpu {
-    version = "cu92-1.2";
+    version = "cu92-1.3";
     buildtype = "cu92";
     mkSrc = buildtype:
       if stdenv.hostPlatform.system == "x86_64-linux" then
         fetchzip {
-          url = "https://download.pytorch.org/libtorch/cu92/libtorch-cxx11-abi-shared-with-deps-1.2.0.zip";
-          sha256 = "0xsq7fw2d36wsfha04dcdd5fwi24h8hg7hqkd7l29g1cpfcvr4na";
+          # Source file is "https://download.pytorch.org/libtorch/cu92/libtorch-cxx11-abi-shared-with-deps-1.3.0%2Bcu92.zip".
+          # Nix can not use the url directly, because this link includes '%2B'.
+          url = "https://github.com/hasktorch/libtorch-binary-for-ci/releases/download/1.3.0/cu92-libtorch-cxx11-abi-shared-with-deps-latest.zip";
+          sha256 = "1xda0bkh7sgdcsng8vajs8rsg6xpdajvm1ycksrmi4jd8ifl772d";
         }
       else throw "missing url for platform ${stdenv.hostPlatform.system}";
   };

--- a/libtorch/shell.nix
+++ b/libtorch/shell.nix
@@ -5,7 +5,7 @@ let
 in
 pkgs.mkShell {
   buildInputs = [
-    build.nightly.libtorch_cudatoolkit_10_0
+    build.libtorch_cudatoolkit_10_1
     pkgs.clang_7
   ];
 }


### PR DESCRIPTION
This PR upgrades libtorch to 1.3.

The url of prebuild-libtorch includes "%2B".
(For example, the url is https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.3.0%2Bcpu.zip.)

fetchurl-function of nix can not accept the url. 
So this pr uses the renamed file of libtorch-binary-for-ci's repo.
