### PR TITLE
Add RPATH for libtorch's binaries

### DIFF
--- a/libtorch/generic.nix
+++ b/libtorch/generic.nix
@@ -18,40 +18,13 @@ stdenv.mkDerivation rec {
     done
     for f in $(ls $out/lib/*.dylib); do
       install_name_tool -id $out/lib/$(basename $f) $f || true
+      for rpath in $(otool -L $f | grep rpath | awk 'NR>1 {print $1}');do
+        install_name_tool -change $rpath $out/lib/$(basename $rpath) $f
+      done
+      if otool -L $f | grep /usr/lib/libc++ >& /dev/null ;then
+        install_name_tool -change /usr/lib/libc++.1.dylib  $libcxxPath/lib/libc++.1.0.dylib $f
+      fi
     done
-    install_name_tool -change @rpath/libc10.dylib       $out/lib/libc10.dylib   $out/lib/libcaffe2_detectron_ops.dylib
-    install_name_tool -change @rpath/libc10.dylib       $out/lib/libc10.dylib   $out/lib/libcaffe2_module_test_dynamic.dylib
-    install_name_tool -change @rpath/libc10.dylib       $out/lib/libc10.dylib   $out/lib/libcaffe2_observers.dylib
-    install_name_tool -change @rpath/libc10.dylib       $out/lib/libc10.dylib   $out/lib/libpytorch_jni.dylib
-    install_name_tool -change @rpath/libc10.dylib       $out/lib/libc10.dylib   $out/lib/libshm.dylib
-    install_name_tool -change @rpath/libc10.dylib       $out/lib/libc10.dylib   $out/lib/libtorch.dylib
-    install_name_tool -change @rpath/libc10.dylib       $out/lib/libc10.dylib   $out/lib/libtorch_cpu.dylib
-    install_name_tool -change @rpath/libc10.dylib       $out/lib/libc10.dylib   $out/lib/libtorch_python.dylib
-    install_name_tool -change @rpath/libfbjni.dylib     $out/lib/libfbjni.dylib $out/lib/libpytorch_jni.dylib
-    install_name_tool -change @rpath/libshm.dylib       $out/lib/libshm.dylib   $out/lib/libtorch_python.dylib
-    install_name_tool -change @rpath/libtorch.dylib     $out/lib/libtorch.dylib $out/lib/libcaffe2_detectron_ops.dylib
-    install_name_tool -change @rpath/libtorch.dylib     $out/lib/libtorch.dylib $out/lib/libcaffe2_module_test_dynamic.dylib
-    install_name_tool -change @rpath/libtorch.dylib     $out/lib/libtorch.dylib $out/lib/libcaffe2_observers.dylib
-    install_name_tool -change @rpath/libtorch.dylib     $out/lib/libtorch.dylib $out/lib/libshm.dylib
-    install_name_tool -change @rpath/libtorch.dylib     $out/lib/libtorch.dylib $out/lib/libpytorch_jni.dylib
-    install_name_tool -change @rpath/libtorch.dylib     $out/lib/libtorch.dylib $out/lib/libtorch_python.dylib
-    install_name_tool -change @rpath/libtorch_cpu.dylib $out/lib/libtorch_cpu.dylib $out/lib/libcaffe2_detectron_ops.dylib
-    install_name_tool -change @rpath/libtorch_cpu.dylib $out/lib/libtorch_cpu.dylib $out/lib/libcaffe2_module_test_dynamic.dylib
-    install_name_tool -change @rpath/libtorch_cpu.dylib $out/lib/libtorch_cpu.dylib $out/lib/libcaffe2_observers.dylib
-    install_name_tool -change @rpath/libtorch_cpu.dylib $out/lib/libtorch_cpu.dylib $out/lib/libtorch.dylib
-    install_name_tool -change @rpath/libtorch_cpu.dylib $out/lib/libtorch_cpu.dylib $out/lib/libpytorch_jni.dylib
-    install_name_tool -change @rpath/libtorch_cpu.dylib $out/lib/libtorch_cpu.dylib $out/lib/libshm.dylib
-    install_name_tool -change @rpath/libtorch_cpu.dylib $out/lib/libtorch_cpu.dylib $out/lib/libtorch_python.dylib
-    install_name_tool -change @rpath/libiomp5.dylib $out/lib/libiomp5.dylib $out/lib/libtorch_global_deps.dylib
-
-
-    for i in libtorch.dylib libtorch_cpu.dylib libpytorch_jni.dylib libcaffe2_detectron_ops.dylib libcaffe2_module_test_dynamic.dylib libcaffe2_observers.dylib libshm.dylib libtorch_python.dylib ; do 
-      install_name_tool -change @rpath/libiomp5.dylib $out/lib/libiomp5.dylib $out/lib/$i
-      install_name_tool -change /usr/lib/libc++.1.dylib $libcxxPath/lib/libc++.1.0.dylib $out/lib/$i
-    done
-    install_name_tool -change @rpath/libiomp5.dylib $out/lib/libiomp5.dylib $out/lib/libtorch_global_deps.dylib
-    install_name_tool -change /usr/lib/libc++.1.dylib $libcxxPath/lib/libc++.1.0.dylib $out/lib/libc10.dylib
-    install_name_tool -change /usr/lib/libc++.1.dylib $libcxxPath/lib/libc++.1.0.dylib $out/lib/libfbjni.dylib
     echo "-- after fixup --"
     for f in $(ls $out/lib/*.dylib); do
         otool -L $f


### PR DESCRIPTION
This pr changes RPATH of libtorch's binaries to read driver-files in /run/opengl-drivers/lib  directory.
It uses the same functions as tensorflow's modification taught by stites.
https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/python-modules/tensorflow/default.nix#L382-L388
