### PR TITLE
Support for libtorch-1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Features
 
 The current features are supported:
 
-| **Python-3.6.9 support**            | pytorch-v1.1.0     | pytorch-v1.2.0     | libtorch-v1.4.0    |
+| **Python-3.6.9 support**            | pytorch-v1.1.0     | pytorch-v1.2.0     | libtorch-v1.6.0    |
 | ----------------------------------- | ------------------ | ------------------ | ------------------ |
 | vanilla                             | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | mkl+mkldnn                          | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |

--- a/libtorch/generic.nix
+++ b/libtorch/generic.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchzip, autoreconfHook, gettext
-, version ? "1.5", mkSrc, buildtype
+, version ? "1.6", mkSrc, buildtype
 , libcxx ? null
 }:
 

--- a/libtorch/release.nix
+++ b/libtorch/release.nix
@@ -16,56 +16,56 @@ in
   libmklml = libmklml { useIomp5 = true; };
   libmklml_without_iomp5 = libmklml { useIomp5 = false; };
   libtorch_cpu = callCpu {
-    version = "1.5";
+    version = "1.6";
     buildtype = "cpu";
     mkSrc = buildtype:
       if stdenv.hostPlatform.system == "x86_64-linux" then
         fetchzip {
-          # Source file is  "https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.5.0%2Bcpu.zip".
+          # Source file is  "https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.6.0%2Bcpu.zip".
           # Nix can not use the url directly, because this link includes '%2B'.
-          url = "https://github.com/hasktorch/libtorch-binary-for-ci/releases/download/1.5.0/cpu-libtorch-cxx11-abi-shared-with-deps-latest.zip";
-          sha256 = "1acz4n7d8k0cjlrysjmls05sdj9klwh0j603pdb2qdq5abclm3dl";
+          url = "https://github.com/hasktorch/libtorch-binary-for-ci/releases/download/1.6.0/cpu-libtorch-cxx11-abi-shared-with-deps-latest.zip";
+          sha256 = "1975b4zvyihzh89vnwspw0vf9qr05sxj8939vcrlmv3gzvdspcxz";
         }
       else if stdenv.hostPlatform.system == "x86_64-darwin" then
         fetchzip {
-          url = "https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.5.0.zip";
-          sha256 = "1hrhpy4yn8z5sjqwafib2wnla5isx7cg586qv1cbpdcl4am6z8v7";
+          url = "https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.6.0.zip";
+          sha256 = "0d4n7la31qzl4s9pwvm07la7q6lhcwiww0yjpfz3kw6nvx84p22r";
         }
       else throw "missing url for platform ${stdenv.hostPlatform.system}";
   };
   ${if stdenv.hostPlatform.system == "x86_64-darwin" then null else "libtorch_cudatoolkit_10_2"} = callGpu {
-    version = "cu102-1.5";
+    version = "cu102-1.6";
     buildtype = "cu102";
     mkSrc = buildtype:
       if stdenv.hostPlatform.system == "x86_64-linux" then
         fetchzip {
-          url = "https://download.pytorch.org/libtorch/cu102/libtorch-cxx11-abi-shared-with-deps-1.5.0.zip";
-          sha256 = "1ps8k2qgw5jrzv3gbsaw301ipvakflnmgh3nv5ppaanxdybdadlp";
+          url = "https://download.pytorch.org/libtorch/cu102/libtorch-cxx11-abi-shared-with-deps-1.6.0.zip";
+          sha256 = "127qnfyi1faqbm40sbnsyqxjhrqj82bzwqyz7c1hs2bm0zgrrpya";
         }
       else throw "missing url for platform ${stdenv.hostPlatform.system}";
   };
   ${if stdenv.hostPlatform.system == "x86_64-darwin" then null else "libtorch_cudatoolkit_10_1"} = callGpu {
-    version = "cu101-1.5";
+    version = "cu101-1.6";
     buildtype = "cu101";
     mkSrc = buildtype:
       if stdenv.hostPlatform.system == "x86_64-linux" then
         fetchzip {
-          # Source file is "https://download.pytorch.org/libtorch/cu101/libtorch-cxx11-abi-shared-with-deps-1.5.0%2Bcu101.zip".
-          url = "https://github.com/hasktorch/libtorch-binary-for-ci/releases/download/1.5.0/cu101-libtorch-cxx11-abi-shared-with-deps-latest.zip";
-          sha256 = "0712ix9inwijzq23k3ac58imlqj1y4x93i2k4hv1md44jhbz06zr";
+          # Source file is "https://download.pytorch.org/libtorch/cu101/libtorch-cxx11-abi-shared-with-deps-1.6.0%2Bcu101.zip".
+          url = "https://github.com/hasktorch/libtorch-binary-for-ci/releases/download/1.6.0/cu101-libtorch-cxx11-abi-shared-with-deps-latest.zip";
+          sha256 = "0syxsdca42ns00x4gy9pwlxhw81vhc3575agl8siwl96nmb25794";
         }
       else throw "missing url for platform ${stdenv.hostPlatform.system}";
   };
   ${if stdenv.hostPlatform.system == "x86_64-darwin" then null else "libtorch_cudatoolkit_9_2"} = callGpu {
-    version = "cu92-1.5";
+    version = "cu92-1.6";
     buildtype = "cu92";
     mkSrc = buildtype:
       if stdenv.hostPlatform.system == "x86_64-linux" then
         fetchzip {
-          # Source file is "https://download.pytorch.org/libtorch/cu92/libtorch-cxx11-abi-shared-with-deps-1.5.0%2Bcu92.zip".
+          # Source file is "https://download.pytorch.org/libtorch/cu92/libtorch-cxx11-abi-shared-with-deps-1.6.0%2Bcu92.zip".
           # Nix can not use the url directly, because this link includes '%2B'.
-          url = "https://github.com/hasktorch/libtorch-binary-for-ci/releases/download/1.5.0/cu92-libtorch-cxx11-abi-shared-with-deps-latest.zip";
-          sha256 = "00vnbc3sv4gdmvic7nvf3jr1mmaf2gms3r4q6ifsskahyinxhyxl";
+          url = "https://github.com/hasktorch/libtorch-binary-for-ci/releases/download/1.6.0/cu92-libtorch-cxx11-abi-shared-with-deps-latest.zip";
+          sha256 = "11nirp7j380fylgjpcxdd9nac2bwrxwf3wkwzdj4ajmswirgwxxm";
         }
       else throw "missing url for platform ${stdenv.hostPlatform.system}";
   };


### PR DESCRIPTION
Preparing for upgrading hasktorch.
https://pytorch.org/blog/pytorch-1.6-released/
